### PR TITLE
Fix unmappable character

### DIFF
--- a/src/org/acoli/conll/transform/Transformer.java
+++ b/src/org/acoli/conll/transform/Transformer.java
@@ -209,7 +209,7 @@ public class Transformer {
 	public static void main(String[] args) {
 		String baseuri = Transformer.DEFAULT_URI;
 		if(args.length <1  ||  !args[0].equals("-silent"))
-			System.err.println("synopsis: Transformer [-silent] SRC TGT OWL´[BASEURI]\n"+
+			System.err.println("synopsis: Transformer [-silent] SRC TGT OWL [BASEURI]\n"+
 					"\t-silent suppress this message\n"+
 					"\tSRC     source format\n"+
 					"\tTGT     target format\n"+


### PR DESCRIPTION


Fixes error below on macOS 10.14 and Ubuntu 16.04

src/org/acoli/conll/transform/Transformer.java:212: error: unmappable character (0xB4) for encoding UTF-8
			System.err.println("synopsis: Transformer [-silent] SRC TGT OWL�[BASEURI]\n"+
			                                                   